### PR TITLE
Update Largo to 0.6.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = git@github.com:INN/deploy-tools.git
 [submodule "wp-content/themes/largo"]
 	path = wp-content/themes/largo
-	url = git@github.com:INN/Largo.git
+	url = git@github.com:INN/largo.git
 [submodule "wp-content/plugins/client-hosting-manager"]
 	path = wp-content/plugins/client-hosting-manager
 	url = git@github.com:INN/client-hosting-manager.git


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Updates Largo to 0.6.4
- Updates the submodule to use `git@github.com:INN/largo.git` instead of `git@github.com:INN/Largo.git`

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #1

## Testing/Questions

Features that this PR affects:

- Largo parent theme

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?